### PR TITLE
feat: add initial support to sort by multiple columns

### DIFF
--- a/src/main/java/app/tozzi/model/input/JPASearchInput.java
+++ b/src/main/java/app/tozzi/model/input/JPASearchInput.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Data
@@ -23,11 +24,19 @@ public class JPASearchInput {
 
     @Data
     public static class JPASearchOptions {
-        private String sortKey;
-        private Boolean sortDesc = false;
         private Integer pageSize;
         private Integer pageOffset;
         private List<String> selections;
+        private List<SortOption> sortOptions;
+
+        public JPASearchOptions addSortOption(SortOption sortOption) {
+            if (this.sortOptions == null) {
+                this.sortOptions = new ArrayList<>();
+            }
+            this.sortOptions.add(sortOption);
+
+            return this;
+        }
     }
 
     @JsonTypeInfo(
@@ -82,6 +91,12 @@ public class JPASearchInput {
         private boolean ignoreCase;
         private boolean trim;
         private boolean negate;
+    }
+
+    @Data
+    public static class SortOption {
+        private String sortKey;
+        private Boolean sortDesc;
     }
 
 }

--- a/src/main/java/app/tozzi/util/JPASearchUtils.java
+++ b/src/main/java/app/tozzi/util/JPASearchUtils.java
@@ -62,8 +62,12 @@ public class JPASearchUtils {
                             case LIMIT -> res.getOptions().setPageSize(GenericUtils.loadInt(e.getValue(), processPaginationOptions ? 0 : -1));
                             case OFFSET -> res.getOptions().setPageOffset(GenericUtils.loadInt(e.getValue(), 0));
                             case SORT -> {
-                                res.getOptions().setSortKey(e.getKey().substring(0, e.getKey().lastIndexOf("_")));
-                                res.getOptions().setSortDesc(JPASearchSortType.DESC.name().equalsIgnoreCase(e.getValue()));
+                                var sortKey = e.getKey().substring(0, e.getKey().lastIndexOf("_"));
+                                var sortDesc = JPASearchSortType.DESC.name().equalsIgnoreCase(e.getValue());
+                                var sortOption = new JPASearchInput.SortOption();
+                                sortOption.setSortKey(sortKey);
+                                sortOption.setSortDesc(sortDesc);
+                                res.getOptions().addSortOption(sortOption);
                             }
                         }
 

--- a/src/test/java/app/tozzi/core/JPASearchCoreTest.java
+++ b/src/test/java/app/tozzi/core/JPASearchCoreTest.java
@@ -237,8 +237,10 @@ public class JPASearchCoreTest {
     @Test
     void mode2_onlySortingWithoutFilters() {
         var options = new JPASearchInput.JPASearchOptions();
-        options.setSortKey("stringOne");
-        options.setSortDesc(true);
+        var sortOption = new JPASearchInput.SortOption();
+        sortOption.setSortKey("stringOne");
+        sortOption.setSortDesc(true);
+        options.addSortOption(sortOption);
         var input = new JPASearchInput();
         input.setOptions(options);
 
@@ -253,8 +255,10 @@ public class JPASearchCoreTest {
         var options = new JPASearchInput.JPASearchOptions();
         options.setPageOffset(0);
         options.setPageSize(50);
-        options.setSortKey("stringOne");
-        options.setSortDesc(true);
+        var sortOption = new JPASearchInput.SortOption();
+        sortOption.setSortKey("stringOne");
+        sortOption.setSortDesc(true);
+        options.addSortOption(sortOption);
         var input = new JPASearchInput();
         input.setOptions(options);
 
@@ -377,8 +381,10 @@ public class JPASearchCoreTest {
 
         input.setOptions(new JPASearchInput.JPASearchOptions());
         input.getOptions().setSelections(List.of("stringMail", "mySubModel.searchMe"));
-        input.getOptions().setSortKey("stringMail");
-        input.getOptions().setSortDesc(true);
+        var sortOption = new JPASearchInput.SortOption();
+        sortOption.setSortKey("stringMail");
+        sortOption.setSortDesc(true);
+        input.getOptions().addSortOption(sortOption);
 
         List<Map<String, Object>> res = myRepository.projectionWithSorting(input, MyModel.class, MyEntity.class);
         assertNotNull(res);
@@ -430,8 +436,10 @@ public class JPASearchCoreTest {
 
         input.setOptions(new JPASearchInput.JPASearchOptions());
         input.getOptions().setSelections(List.of("stringMail", "mySubModel.searchMe"));
-        input.getOptions().setSortKey("stringMail");
-        input.getOptions().setSortDesc(false);
+        var sortOption = new JPASearchInput.SortOption();
+        sortOption.setSortKey("stringMail");
+        sortOption.setSortDesc(false);
+        input.getOptions().addSortOption(sortOption);
 
         List<Map<String, Object>> res = myRepository.projectionWithSorting(input, MyModel.class, MyEntity.class);
         assertNotNull(res);

--- a/src/test/java/app/tozzi/util/JPASearchUtilsTest.java
+++ b/src/test/java/app/tozzi/util/JPASearchUtilsTest.java
@@ -91,8 +91,9 @@ public class JPASearchUtilsTest {
         assertNotNull(input.getOptions());
         assertEquals(1, input.getOptions().getPageOffset());
         assertEquals(10, input.getOptions().getPageSize());
-        assertEquals("id", input.getOptions().getSortKey());
-        assertEquals(true, input.getOptions().getSortDesc());
+        var firstSortOption = input.getOptions().getSortOptions().get(0);
+        assertEquals("id", firstSortOption.getSortKey());
+        assertEquals(true, firstSortOption.getSortDesc());
         assertNotNull(input.getFilter());
         assertEquals("and", input.getFilter().getOperator());
         assertNotNull(input.getFilter().getFilters());
@@ -119,8 +120,9 @@ public class JPASearchUtilsTest {
         assertNotNull(input.getOptions());
         assertEquals(1, input.getOptions().getPageOffset());
         assertEquals(10, input.getOptions().getPageSize());
-        assertEquals("id", input.getOptions().getSortKey());
-        assertEquals(false, input.getOptions().getSortDesc());
+        var firstSortOption = input.getOptions().getSortOptions().get(0);
+        assertEquals("id", firstSortOption.getSortKey());
+        assertEquals(false, firstSortOption.getSortDesc());
         assertNotNull(input.getFilter());
         assertEquals("and", input.getFilter().getOperator());
         assertNotNull(input.getFilter().getFilters());


### PR DESCRIPTION
Hi @biagioT,
I made some modifications in your library to support sorting by multiple columns, this is the first initial version and its **not** backward compatible **yet**, because I modified the structure of the `JPASearchOptions` class.

I'm looking forward to hear your opinion about the modifications, and whether you think I should continue work on this feature.
